### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ node_js:
 before_install:
 - npm config set spin false
 - npm install -g bower
-- npm install -g ember-cli@v2.10.0
+- npm install -g ember-cli@v2.13.0
 - npm install -g istanbul
 install:
 - npm i

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "start": "ember server",
     "test": "ember try:testall",
     "deploy": "./publish.sh",
-    "generate-coverage": "ember test --test-page='tests/index.html?coverage=true'",
-    "coverage": "npm run generate-coverage && cat lcov.dat | CODACY_PROJECT_TOKEN=ca5159a3391d43db90a053c83cb34eea ./node_modules/.bin/codacy-coverage"
+    "generate-coverage": "COVERAGE=true ember test",
+    "coverage": "npm run generate-coverage && cat coverage/lcov.info | CODACY_PROJECT_TOKEN=ca5159a3391d43db90a053c83cb34eea ./node_modules/.bin/codacy-coverage"
   },
   "repository": {
     "type": "git",
@@ -32,6 +32,7 @@
     "codacy-coverage": "^2.0.0",
     "ember-cli": "^2.13.1",
     "ember-cli-app-version": "^3.0.0",
+    "ember-cli-code-coverage": "^0.3.12",
     "ember-cli-dependency-checker": "^1.4.0",
     "ember-cli-doc-server": "1.1.0",
     "ember-cli-htmlbars-inline-precompile": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -30,28 +30,28 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.5.0",
     "codacy-coverage": "^2.0.0",
-    "ember-cli": "^2.11.0",
-    "ember-cli-app-version": "^2.0.1",
-    "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli": "^2.13.1",
+    "ember-cli-app-version": "^3.0.0",
+    "ember-cli-dependency-checker": "^1.4.0",
     "ember-cli-doc-server": "1.1.0",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
+    "ember-cli-htmlbars-inline-precompile": "^0.4.2",
     "ember-cli-inject-live-reload": "^1.6.1",
     "ember-cli-jsdoc": "^1.5.2",
     "ember-cli-jshint": "^2.0.1",
     "ember-cli-qunit": "^3.1.0",
     "ember-cli-release": "^1.0.0-beta.2",
-    "ember-cli-sass": "6.1.1",
-    "ember-cli-shims": "^1.0.2",
+    "ember-cli-sass": "^6.1.3",
+    "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-export-application-global": "^1.1.1",
-    "ember-i18n": "^4.5.0",
-    "ember-load-initializers": "^0.6.3",
-    "ember-resolver": "^2.1.1",
-    "ember-source": "2.11.0",
+    "ember-export-application-global": "^2.0.0",
+    "ember-i18n": "^5.0.1",
+    "ember-load-initializers": "^1.0.0",
+    "ember-resolver": "^4.1.0",
+    "ember-source": "^2.13.0",
     "ink-docstrap": "^1.3.0",
-    "loader.js": "^4.1.0"
+    "loader.js": "^4.4.0"
   },
   "keywords": [
     "ember-addon",
@@ -61,8 +61,8 @@
     "popup"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.2.1",
-    "ember-cli-htmlbars": "^1.1.1"
+    "ember-cli-babel": "^6.1.0",
+    "ember-cli-htmlbars": "^1.3.0"
   },
   "ember-addon": {
     "demoURL": "http://wheely.github.io/ember-dialog/",


### PR DESCRIPTION
All dependencies were updated — that solves the issue wheely/ember-dialog#93.

This pull request based on wheely/ember-dialog#94 (that should go first), because after updating dependencies in this PR, the dummy application crashes without it.