### PR TITLE
[WEB-344] Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Fanis-Rakhmatullin


### PR DESCRIPTION
## Why
Per the Frontend Sync decision (2026-06-04), this project gets explicit code owners so PRs have a clear, accountable reviewer.

## What
Add `CODEOWNERS` with the owner agreed for this repo.

cc @Fanis-Rakhmatullin